### PR TITLE
#3 prototype-controller 投稿に関して

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -15,7 +15,7 @@ class PrototypesController < ApplicationController
     if @prototype.save
       redirect_to :root, notice: 'New prototype was successfully created'
     else
-      redirect_to ({ action: new }), alert: 'YNew prototype was unsuccessfully created'
+      redirect_to :new_prototype, alert: 'YNew prototype was unsuccessfully created'
      end
   end
 


### PR DESCRIPTION
WHAT
リダイレクト先の指定と、登録未完了メッセージの表示

WHY
登録不可を通知し、再入力を求めるため